### PR TITLE
build(deps): bump kube-rbac-proxy from v0.11.0 to v0.14.1

### DIFF
--- a/charts/gateway-helm/values.tmpl.yaml
+++ b/charts/gateway-helm/values.tmpl.yaml
@@ -14,7 +14,7 @@ deployment:
   kubeRbacProxy:
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.11.0
+      tag: v0.14.1
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
**What type of PR is this?**

- bump kubebuilder/kube-rbac-proxy from v0.11.0 to v0.14.1

**What this PR does / why we need it**:

- bump kubebuilder/kube-rbac-proxy from v0.11.0 to v0.14.1
  - kube-rbac-proxy image is stale.

**Which issue(s) this PR fixes**:

- none.